### PR TITLE
Use the python2 method for setting a timeout

### DIFF
--- a/impala/hiveserver2.py
+++ b/impala/hiveserver2.py
@@ -809,7 +809,8 @@ def connect(host, port, timeout=None, use_ssl=False, ca_cert=None,
 
         if timeout is not None:
             timeout = timeout * 1000.  # TSocket expects millis
-        if six.PY2:
+        # Use the python2 method -- Deepfield
+        if six.PY2 or True:
             sock.setTimeout(timeout)
         elif six.PY3:
             try:


### PR DESCRIPTION
While working on https://deepfield.atlassian.net/browse/CPL-7345 we realized the timeout wasn't being respected -- fix the check to still do the python2 method.